### PR TITLE
Widen intro paragraph to span text + image width of project blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 		<div class="col-xl-4 col-lg-3 col-sm-2 col-xs-3"></div>
 		<div class="col-12 vspace1em"></div>
 		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-    	<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10 intro-copy" data-aos="fade-up" data-aos-once="true">
+    	<div class="col-xl-8 col-lg-10 col-md-8 col-xs-10 intro-copy" data-aos="fade-up" data-aos-once="true">
 			<p>Specializing in enterprise-grade tools, dashboards, and accessibility. I lead end-to-end design, from user research to high-fidelity Figma prototyping, to create scalable solutions that impact thousands of users daily.</p>
 			<div class="vspacehalfem"></div>
 			<p>Take a look at some of my recent work samples below. Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>


### PR DESCRIPTION
Change the intro-copy column from col-xl-5/col-lg-6 (matching only the project blocks' text column) to col-xl-8/col-lg-10 (matching text + image combined), so its right edge lines up with the thumbnail images in the case study list below.