### PR TITLE
Hide Walmart project from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,6 @@
 				<button type="button" class="filter-btn" data-filter="usability-testing">Usability Testing</button>
 				<button type="button" class="filter-btn" data-filter="ui-design">UI Design</button>
 				<button type="button" class="filter-btn" data-filter="data-visualization">Data Visualization</button>
-				<button type="button" class="filter-btn" data-filter="graphic-design">Graphic Design</button>
 			</div>
 		</div>
 	</div>
@@ -238,8 +237,8 @@
 		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
 		<div class="col-12 vspace4em"></div>
 	</div>
-	<!--walmart-->
-	<div class="row mx-4 d-flex align-items-center" data-categories="graphic-design,ui-design">
+	<!--walmart - hidden from home page-->
+	<div class="row mx-4 d-flex align-items-center" style="display: none !important;">
 		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
 		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
 			<div class="vspacehalfem"></div>


### PR DESCRIPTION
Same pattern as the AI chatbot entry: hide via inline display:none!important (Bootstrap's .d-flex !important would otherwise win the specificity tie against a plain .d-none class) and drop its data-categories attribute so the filter script's [data-categories] query skips it entirely - otherwise clicking a matching filter would call removeProperty('display') and undo the hide.

Also remove the now-dead "Graphic Design" filter button, since Walmart was its only match.