### PR TITLE
Re-center all text blocks into one column that flows down the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,7 @@
 		</div>
 		<div class="col-xl-4 col-lg-3 col-sm-2 col-xs-3"></div>
 		<div class="col-12 vspace1em"></div>
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-    	<div class="col-xl-8 col-lg-10 col-md-8 col-xs-10 intro-copy text-col" data-aos="fade-up" data-aos-once="true">
+    	<div class="intro-copy text-col" data-aos="fade-up" data-aos-once="true">
 			<p>Specializing in enterprise-grade tools, dashboards, and accessibility. I lead end-to-end design, from user research to high-fidelity Figma prototyping, to create scalable solutions that impact thousands of users daily.</p>
 			<div class="vspacehalfem"></div>
 			<p>Take a look at some of my recent work samples below. Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>
@@ -86,8 +85,7 @@
 	</div>
 	<!--design heading-->
 	<div class="row mx-4" id="work">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10" data-aos="fade-up" data-aos-once="true">
+		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 id="whitetext" class="rock-heading">Design</h1>
 		</div>
 	</div>
@@ -97,17 +95,14 @@
 	</div>
 	<!--category filter-->
 	<div class="row mx-4">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-8 col-lg-10 col-md-8 col-xs-10">
-			<div class="filter-bar" role="group" aria-label="Filter projects by category">
-				<button type="button" class="filter-btn active" data-filter="all">All</button>
-				<button type="button" class="filter-btn" data-filter="strategy">Strategy</button>
-				<button type="button" class="filter-btn" data-filter="research">Research</button>
-				<button type="button" class="filter-btn" data-filter="ux">UX</button>
-				<button type="button" class="filter-btn" data-filter="usability-testing">Usability Testing</button>
-				<button type="button" class="filter-btn" data-filter="ui">UI</button>
-				<button type="button" class="filter-btn" data-filter="data-visualization">Data Visualization</button>
-			</div>
+		<div class="filter-bar" role="group" aria-label="Filter projects by category">
+			<button type="button" class="filter-btn active" data-filter="all">All</button>
+			<button type="button" class="filter-btn" data-filter="strategy">Strategy</button>
+			<button type="button" class="filter-btn" data-filter="research">Research</button>
+			<button type="button" class="filter-btn" data-filter="ux">UX</button>
+			<button type="button" class="filter-btn" data-filter="usability-testing">Usability Testing</button>
+			<button type="button" class="filter-btn" data-filter="ui">UI</button>
+			<button type="button" class="filter-btn" data-filter="data-visualization">Data Visualization</button>
 		</div>
 	</div>
 	<!--white space-->
@@ -116,29 +111,22 @@
 		<div class="d-xs-block d-md-none col-xs-12 vspace3em"></div>
 	</div>
 	<!--ai trainingchatbot - hidden from home page-->
-	<div class="row mx-4 d-flex align-items-center" style="display: none !important;">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
-			<div class="vspacehalfem"></div>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>FEDERAL AGENCY - Password Protected</p>
-			</div>
-			<h4 class="px-4" type="link-primary" class=link-primary>
-				<a href="ai-chatbot-scaling.html">Scaling an AI Training Chatbot Across a Government Agency</a>
-			</h4>
-			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Scaled a proof-of-concept training chatbot to meet an agency-wide training demand, improving conversation UX, onboarding flow, and cost optimization.</p>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>Conversation Design // Product Strategy</p>
+	<div class="mx-4" style="display: none !important;">
+		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
+			<div class="project-text-inner">
+				<div class="lowlight">
+					<p id=whitetext>FEDERAL AGENCY - Password Protected</p>
+				</div>
+				<h4 type="link-primary" class=link-primary>
+					<a href="ai-chatbot-scaling.html">Scaling an AI Training Chatbot Across a Government Agency</a>
+				</h4>
+				<div class="vspacehalfem"></div>
+				<p id=whitetext>Scaled a proof-of-concept training chatbot to meet an agency-wide training demand, improving conversation UX, onboarding flow, and cost optimization.</p>
+				<div class="lowlight">
+					<p id=whitetext>Conversation Design // Product Strategy</p>
+				</div>
 			</div>
 		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="d-lg-none col-12 vspace1em"></div> <!--md and smaller extra spacing-->
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-xl-3 col-lg-4 col-md-8 col-xs-8" data-aos="fade-up" data-aos-once="true">
-		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="col-12 vspace4em"></div>
 	</div>
 	<!--accessibility practices
 	<div class="row mx-4 d-flex align-items-center">
@@ -169,114 +157,86 @@
 		<div class="col-12 vspace3em"></div>
 	</div>
 	<!--training team-->
-	<div class="row mx-4 d-flex align-items-center" data-categories="strategy,research,ux">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
-			<div class="vspacehalfem"></div>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>FEDERAL AGENCY - Password Protected</p>
-			</div>
-			<h4 class="px-4" type="link-primary" class=link-primary>
-				<a href="Training-Team.html">Leading an Enterprise Training &amp; Enablement Initiative</a>
-			</h4>
-			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Identified critical training gap and won stakeholder buy-in for new product team. Developed strategic proposal that secured resources for ongoing technical enablement.</p>
-			<div class="tag-list px-4">
-				<button type="button" class="tag-pill" data-filter="strategy">Strategy</button>
-				<button type="button" class="tag-pill" data-filter="research">Research</button>
-				<button type="button" class="tag-pill" data-filter="ux">UX</button>
+	<div class="mx-4" data-categories="strategy,research,ux">
+		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
+			<a href="Training-Team.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/training-team-thumbnail.png" alt="A learning management system interface"></a>
+			<div class="project-text-inner">
+				<div class="lowlight">
+					<p id=whitetext>FEDERAL AGENCY - Password Protected</p>
+				</div>
+				<h4 type="link-primary" class=link-primary>
+					<a href="Training-Team.html">Leading an Enterprise Training &amp; Enablement Initiative</a>
+				</h4>
+				<div class="vspacehalfem"></div>
+				<p id=whitetext>Identified critical training gap and won stakeholder buy-in for new product team. Developed strategic proposal that secured resources for ongoing technical enablement.</p>
+				<div class="tag-list">
+					<button type="button" class="tag-pill" data-filter="strategy">Strategy</button>
+					<button type="button" class="tag-pill" data-filter="research">Research</button>
+					<button type="button" class="tag-pill" data-filter="ux">UX</button>
+				</div>
 			</div>
 		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="d-lg-none col-12 vspace1em"></div> <!--md and smaller extra spacing-->
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-xl-3 col-lg-4 col-md-8 col-xs-8" data-aos="fade-up" data-aos-once="true">
-			<a href="Training-Team.html"><img class="img-fluid float-right p-r-5" src="Images/training-team-thumbnail.png" alt="A learning management system interface" data-aos="fade-up" data-aos-once="true"></a>
-		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="col-12 vspace4em"></div>
 	</div>
-	<!--pdf management-->
-	<div class="row mx-4 d-flex align-items-center" data-categories="ux,research,usability-testing">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
-			<div class="vspacehalfem"></div>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>FEDERAL AGENCY</p>
-			</div>
-			<h4 class="px-4" type="link-primary" class=link-primary>
-				<a href="PDF-Management-App.html">PDF Management App Redesign with AI Components</a>
-			</h4>
-			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Led a cross-functional team to redesign a complex enterprise application. Designed new AI tagging tools, improved naviation, and conducted comprehensive user research and testing.</p>
-			<div class="tag-list px-4">
-				<button type="button" class="tag-pill" data-filter="ux">UX</button>
-				<button type="button" class="tag-pill" data-filter="research">Research</button>
-				<button type="button" class="tag-pill" data-filter="usability-testing">Usability Testing</button>
+	<!--pdf management - OPTION B: larger square thumbnail left of centered text-->
+	<div class="mx-4" data-categories="ux,research,usability-testing">
+		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
+			<a href="PDF-Management-App.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/pdf-management-thumbnail.png" alt="A PDF Editor interface"></a>
+			<div class="project-text-inner">
+				<div class="lowlight">
+					<p id=whitetext>FEDERAL AGENCY</p>
+				</div>
+				<h4 type="link-primary" class=link-primary>
+					<a href="PDF-Management-App.html">PDF Management App Redesign with AI Components</a>
+				</h4>
+				<div class="vspacehalfem"></div>
+				<p id=whitetext>Led a cross-functional team to redesign a complex enterprise application. Designed new AI tagging tools, improved naviation, and conducted comprehensive user research and testing.</p>
+				<div class="tag-list">
+					<button type="button" class="tag-pill" data-filter="ux">UX</button>
+					<button type="button" class="tag-pill" data-filter="research">Research</button>
+					<button type="button" class="tag-pill" data-filter="usability-testing">Usability Testing</button>
+				</div>
 			</div>
 		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="d-lg-none col-12 vspace1em"></div> <!--md and smaller extra spacing-->
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-xl-3 col-lg-4 col-md-8 col-xs-8" data-aos="fade-up" data-aos-once="true">
-			<a href="PDF-Management-App.html"><img class="img-fluid float-right" src="Images/pdf-management-thumbnail.png" alt="A PDF Editor interface" data-aos="fade-up" data-aos-once="true"></a>
-		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-12 vspace4em"></div>
 	</div>
 	<!--invesco-->
-	<div class="row mx-4 d-flex align-items-center" data-categories="ui,data-visualization">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
-			<div class="vspacehalfem"></div>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>INVESCO</p>
-			</div>
-			<h4 class="px-4" type="link-primary" class=link-primary>
-				<a href="Invesco-Cloud-Dashboard.html">Cloud Usage Dashboard</a>
-			</h4>
-			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Led UI design for executive dashboard pitched directly to Invesco CFO. Created interactive prototype to visualize complex cloud spending data.</p>
-			<div class="tag-list px-4">
-				<button type="button" class="tag-pill" data-filter="ui">UI</button>
-				<button type="button" class="tag-pill" data-filter="data-visualization">Data Visualization</button>
+	<div class="mx-4" data-categories="ui,data-visualization">
+		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
+			<a href="Invesco-Cloud-Dashboard.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/invesco-cloud-thumbnail.png" alt="An Invesco cloud usage dashboard interface"></a>
+			<div class="project-text-inner">
+				<div class="lowlight">
+					<p id=whitetext>INVESCO</p>
+				</div>
+				<h4 type="link-primary" class=link-primary>
+					<a href="Invesco-Cloud-Dashboard.html">Cloud Usage Dashboard</a>
+				</h4>
+				<div class="vspacehalfem"></div>
+				<p id=whitetext>Led UI design for executive dashboard pitched directly to Invesco CFO. Created interactive prototype to visualize complex cloud spending data.</p>
+				<div class="tag-list">
+					<button type="button" class="tag-pill" data-filter="ui">UI</button>
+					<button type="button" class="tag-pill" data-filter="data-visualization">Data Visualization</button>
+				</div>
 			</div>
 		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="d-lg-none col-12 vspace1em"></div> <!--md and smaller extra spacing-->
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-xl-3 col-lg-4 col-md-8 col-xs-8" data-aos="fade-up" data-aos-once="true">
-			<a href="Invesco-Cloud-Dashboard.html"><img class="img-fluid float-right p-r-5" src="Images/invesco-cloud-thumbnail.png" alt="An Invesco cloud usage dashboard interface" data-aos="fade-up" data-aos-once="true"></a>
-		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="col-12 vspace4em"></div>
 	</div>
 	<!--walmart - hidden from home page-->
-	<div class="row mx-4 d-flex align-items-center" style="display: none !important;">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
-			<div class="vspacehalfem"></div>
-			<div class="lowlight">
-				<p class="px-4" id=whitetext>WALMART</p>
-			</div>
-			<h4 class="px-4" type="link-primary" class=link-primary>
-				<a href="Walmart-Celebrity-Shopping-Carts.html">Celebrity Shopping Carts</a>
-			</h4>
-			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Delivered themed e-commerce assets for Walmart's Q3 celebrity collaborations. Balanced multiple brand identities while maintaining Walmart's design standards.</p>
-			<div class="tag-list px-4">
-				<button type="button" class="tag-pill" data-filter="graphic-design">Graphic Design</button>
-				<button type="button" class="tag-pill" data-filter="ui">UI</button>
+	<div class="mx-4" style="display: none !important;">
+		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
+			<a href="Walmart-Celebrity-Shopping-Carts.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/walmart-celebrity-carts-thumbnail.png" alt="Graphic displaying Walmart Celebrity collaboration photos of Patrick Mahomes, Barbie, and Becky G"></a>
+			<div class="project-text-inner">
+				<div class="lowlight">
+					<p id=whitetext>WALMART</p>
+				</div>
+				<h4 type="link-primary" class=link-primary>
+					<a href="Walmart-Celebrity-Shopping-Carts.html">Celebrity Shopping Carts</a>
+				</h4>
+				<div class="vspacehalfem"></div>
+				<p id=whitetext>Delivered themed e-commerce assets for Walmart's Q3 celebrity collaborations. Balanced multiple brand identities while maintaining Walmart's design standards.</p>
+				<div class="tag-list">
+					<button type="button" class="tag-pill" data-filter="graphic-design">Graphic Design</button>
+					<button type="button" class="tag-pill" data-filter="ui">UI</button>
+				</div>
 			</div>
 		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="d-lg-none col-12 vspace1em"></div> <!--md and smaller extra spacing-->
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin-->
-		<div class="col-xl-3 col-lg-4 col-md-8 col-xs-8" data-aos="fade-up" data-aos-once="true">
-			<a href="Walmart-Celebrity-Shopping-Carts.html"><img class="img-fluid float-right p-r-5" src="Images/walmart-celebrity-carts-thumbnail.png" alt="Graphic displaying Walmart Celebrity collaboration photos of Patrick Mahomes, Barbie, and Becky G" data-aos="fade-up" data-aos-once="true"></a>
-		</div>
-		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
-		<div class="col-12 vspace4em"></div>
 	</div>
 	<!--wedding invitation suite
 	<div class="row mx-4 d-flex align-items-center">
@@ -313,8 +273,7 @@
 	<!--experience-->
 	<div class="row mx-4" id="experience">
 		<div class="col-12 vspace3em"></div>
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10 text-col" data-aos="fade-up" data-aos-once="true">
+		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 id="whitetext" class="rock-heading">Experience</h1>
 			<div class="col-12 vspace2em"></div>
 			<div class="exp-row">
@@ -338,8 +297,7 @@
 	</div>
 	<!--about-->
 	<div class="row mx-4" id="about">
-		<div class="col-xl-2 col-lg-1 col-md-2 col-xs-2"></div>
-		<div class="col-xl-8 col-lg-10 col-md-8 col-xs-10 text-col" data-aos="fade-up" data-aos-once="true">
+		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 id="whitetext" class="rock-heading">About</h1>
 			<div class="col-12 vspace2em"></div>
             <p id="whitetext">My name is Emma Healy, and I'm a Product Designer at Alpha Omega based in New Jersey. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm a certified web accessibility expert. For the past two years, I have been designing improvements to a large federal agency's case management system.</p>

--- a/new_custom.css
+++ b/new_custom.css
@@ -128,6 +128,15 @@ h7 {
 .navbar-custom-bg {
 	background-color: #0A2243;
 }
+@media (max-width: 991.98px) {
+	.navbar-collapse.show,
+	.navbar-collapse.collapsing {
+		background-color: #0a2243;
+		margin: 0 -1rem;
+		padding: 0.5rem 1rem 1rem;
+		box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+	}
+}
 #work, #experience, #about {
 	scroll-margin-top: 90px;
 }

--- a/new_custom.css
+++ b/new_custom.css
@@ -177,7 +177,10 @@ div.vspace8em {
 	margin-right: auto;
 }
 .text-col {
+	width: 100%;
 	max-width: 38rem;
+	margin-left: auto;
+	margin-right: auto;
 }
 .exp-row {
 	display: flex;
@@ -209,8 +212,46 @@ div.vspace8em {
 .filter-bar {
 	display: flex;
 	flex-wrap: wrap;
+	justify-content: center;
 	gap: 0.6rem;
-	padding-left: 1rem;
+	max-width: 46rem;
+	margin-left: auto;
+	margin-right: auto;
+}
+.project-compact {
+	display: flex;
+	align-items: flex-start;
+	gap: 1.75rem;
+	max-width: 44rem;
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 4rem;
+}
+.project-compact .project-text-inner {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+.project-compact .thumb-link {
+	flex: 0 0 auto;
+	display: block;
+}
+.thumb-square {
+	height: 13.5rem;
+	width: auto;
+	object-fit: contain;
+	display: block;
+}
+@media (max-width: 767.98px) {
+	.project-compact {
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+	}
+	.thumb-square {
+		height: auto;
+		width: 100%;
+		max-width: 20rem;
+	}
 }
 .filter-btn {
 	font-family: 'Josefin Sans', sans-serif;


### PR DESCRIPTION
Replace the left-anchored offset+content column pattern (col-xl-2 offset, col-xl-5/8 content) with self-centering blocks throughout: .text-col now sets width:100% + margin:auto in addition to its existing max-width:38rem, so any element using it centers itself without needing a sibling offset column. Applied to the intro paragraph, Design/Experience/About headings, and their content.

Filter bar now centers as its own cluster (max-width 46rem, justify-content:center) instead of sitting in a left-offset column.

Project blocks (Training Team, PDF Management, Invesco, and the two hidden entries) were rewritten from the old Bootstrap col-xl grid system to a single centered "card": .project-compact is a flex row capped at 44rem and centered on the page, with the existing rectangular thumbnail on the left (natural aspect ratio preserved, no cropping) at a fixed 13.5rem height matching the PDF Management block's text height (the reference/standard content length), and the text block filling the remaining space. Below 768px it stacks image-above-text, centered.

Iterated through a few dead ends before landing here: a CSS Grid "stretch thumbnail to match sibling's auto content height" approach hit the classic cyclic-percentage-height problem (grid/flex items default to min-height:auto, which for an <img> falls back to its massive intrinsic pixel size and inflates the whole row) - fixed by measuring the true text height once and hardcoding it, which is fine since the text length is meant to stay consistent across sections.