### PR TITLE
Extend teal accent bar to About and Experience, bolden resume entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,14 +276,16 @@
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 id="whitetext" class="rock-heading">Experience</h1>
 			<div class="col-12 vspace2em"></div>
-			<div class="exp-row">
-				<span id="whitetext">Alpha Omega &mdash; Senior Product Designer</span>
-				<span class="exp-dates">2023&ndash;Present</span>
-			</div>
-			<div class="vspace1em col-12"></div>
-			<div class="exp-row">
-				<span id="whitetext">Publicis Sapient &mdash; UX Designer</span>
-				<span class="exp-dates">2021&ndash;2023</span>
+			<div class="accent-bar">
+				<div class="exp-row">
+					<span id="whitetext" class="role">Alpha Omega &mdash; Senior Product Designer</span>
+					<span class="exp-dates">2023&ndash;Present</span>
+				</div>
+				<div class="vspace1em col-12"></div>
+				<div class="exp-row">
+					<span id="whitetext" class="role">Publicis Sapient &mdash; UX Designer</span>
+					<span class="exp-dates">2021&ndash;2023</span>
+				</div>
 			</div>
 		</div>
 		<div class="col-12 vspace6em"></div>
@@ -300,11 +302,13 @@
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 id="whitetext" class="rock-heading">About</h1>
 			<div class="col-12 vspace2em"></div>
-            <p id="whitetext">My name is Emma Healy, and I'm a Product Designer at Alpha Omega based in New Jersey. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm a certified web accessibility expert. For the past two years, I have been designing improvements to a large federal agency's case management system.</p>
-			<div class="vspace1em col-12"></div>
-			<p id="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries. I graduated from Northwestern University in 2021 with a degree in Communications, Design, and Marketing.</p>
-			<div class="vspace1em col-12"></div>
-            <p id="whitetext">I'm always taking classes, whether oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in West Village. I'm originally from a town called Oconomowoc, Wisconsin, and while I make the most of NYC's incredible food scene, I miss fried cheese curds on the daily.</p>
+			<div class="accent-bar">
+	            <p id="whitetext">My name is Emma Healy, and I'm a Product Designer at Alpha Omega based in New Jersey. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm a certified web accessibility expert. For the past two years, I have been designing improvements to a large federal agency's case management system.</p>
+				<div class="vspace1em col-12"></div>
+				<p id="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries. I graduated from Northwestern University in 2021 with a degree in Communications, Design, and Marketing.</p>
+				<div class="vspace1em col-12"></div>
+	            <p id="whitetext">I'm always taking classes, whether oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in West Village. I'm originally from a town called Oconomowoc, Wisconsin, and while I make the most of NYC's incredible food scene, I miss fried cheese curds on the daily.</p>
+			</div>
 		</div>
 		<div class="col-12 vspace6em"></div>
 	</div>

--- a/new_custom.css
+++ b/new_custom.css
@@ -198,18 +198,24 @@ div.vspace8em {
 	flex-wrap: wrap;
 	gap: 0.35rem 1.5rem;
 }
+.exp-row .role {
+	font-weight: 600;
+	font-size: 1.1rem;
+}
 .exp-dates {
 	font-family: 'Josefin Sans', sans-serif;
-	font-weight: 300;
+	font-weight: 400;
 	font-size: 0.9rem;
-	color: rgba(255, 255, 255, 0.55);
+	color: rgba(255, 255, 255, 0.75);
 	white-space: nowrap;
 }
-.intro-copy {
+.intro-copy,
+.accent-bar {
 	position: relative;
 	padding-left: 1.75rem;
 }
-.intro-copy::before {
+.intro-copy::before,
+.accent-bar::before {
 	content: "";
 	position: absolute;
 	top: 0.25em;


### PR DESCRIPTION
Generalize the intro paragraph's vertical bar into a reusable .accent-bar class (same styling, shared ::before rule) and wrap it around the About paragraphs and the Experience entries - excluding the section headings, matching how the intro bar only wraps the body copy, not the hero name.

Made the Experience section bolder and more readable: company/title text gets a new .role class (weight 600, 1.1rem, up from inherited body weight/size), and the date labels move from weight 300 / 0.55 opacity to weight 400 / 0.75 opacity so they read clearly without competing with the role text.