### PR TITLE
Make Design, Experience, and About headings orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 	<!--design heading-->
 	<div class="row mx-4" id="work">
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
-			<h1 id="whitetext" class="rock-heading">Design</h1>
+			<h1 class="rock-heading">Design</h1>
 		</div>
 	</div>
 	<!--white space-->
@@ -274,7 +274,7 @@
 	<div class="row mx-4" id="experience">
 		<div class="col-12 vspace3em"></div>
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
-			<h1 id="whitetext" class="rock-heading">Experience</h1>
+			<h1 class="rock-heading">Experience</h1>
 			<div class="col-12 vspace2em"></div>
 			<div class="accent-bar">
 				<div class="exp-row">
@@ -300,7 +300,7 @@
 	<!--about-->
 	<div class="row mx-4" id="about">
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
-			<h1 id="whitetext" class="rock-heading">About</h1>
+			<h1 class="rock-heading">About</h1>
 			<div class="col-12 vspace2em"></div>
 			<div class="accent-bar">
 	            <p id="whitetext">My name is Emma Healy, and I'm a Product Designer at Alpha Omega based in New Jersey. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm a certified web accessibility expert. For the past two years, I have been designing improvements to a large federal agency's case management system.</p>

--- a/new_custom.css
+++ b/new_custom.css
@@ -30,6 +30,7 @@ h1.rock-heading {
 	font-size: 1.7rem;
 	text-transform: uppercase;
 	text-align: center;
+	color: #E3920D;
 }
 h2 {
 	font-size: clamp(1.9rem, 1.6rem + 1.3vw, 2.3rem);


### PR DESCRIPTION
Add color: #E3920D to h1.rock-heading and drop id="whitetext" from these three headings, since that ID's white color (higher specificity than a class selector) was overriding the new color.