### PR TITLE
Hide navbar wordmark until user scrolls past the hero wordmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,24 @@
             });
         })();
     </script>
+    <script>
+        (function () {
+            var navBrand = document.querySelector('.navbar-brand');
+            var heroWordmark = document.querySelector('.ornamentation');
+            if (!navBrand || !heroWordmark) return;
+
+            navBrand.classList.add('navbar-brand-hidden');
+
+            function updateNavBrand() {
+                var rect = heroWordmark.getBoundingClientRect();
+                var scrolledPast = rect.bottom < 0;
+                navBrand.classList.toggle('navbar-brand-hidden', !scrolledPast);
+            }
+
+            window.addEventListener('scroll', updateNavBrand, { passive: true });
+            updateNavBrand();
+        })();
+    </script>
 </div>
 </main>
 <footer class="container-fluid">

--- a/new_custom.css
+++ b/new_custom.css
@@ -103,6 +103,12 @@ h7 {
     color: #ffffff !important;
 	text-decoration: none !important;
 	text-transform: uppercase !important;
+	opacity: 1;
+	transition: opacity 200ms ease;
+}
+.navbar-brand.navbar-brand-hidden {
+	opacity: 0;
+	pointer-events: none;
 }
 .navbar-text {
     font-family: 'Josefin Sans', sans-serif;

--- a/new_custom.css
+++ b/new_custom.css
@@ -220,7 +220,7 @@ div.vspace8em {
 .intro-copy,
 .accent-bar {
 	position: relative;
-	padding-left: 1.75rem;
+	padding-left: 2.75rem;
 }
 .intro-copy::before,
 .accent-bar::before {


### PR DESCRIPTION
On index.html only: the nav's "Emma Healy" wordmark starts hidden (opacity:0, non-interactive) and fades in once the hero .ornamentation wordmark has fully scrolled above the viewport, fading back out if the user scrolls back up. Implemented via a scroll listener that toggles a new .navbar-brand-hidden class, added only by index.html's own inline script.

Other pages never run that script, so .navbar-brand's new base opacity:1 + transition (harmless on its own) is the only shared CSS change - their navbar wordmark stays visible exactly as before.