### PR TITLE
Remove active state from Design nav link

### DIFF
--- a/Content-Shortcuts.html
+++ b/Content-Shortcuts.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Invesco-Cloud-Dashboard.html
+++ b/Invesco-Cloud-Dashboard.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/PDF-Management-App.html
+++ b/PDF-Management-App.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Scaling-Accessibility-Practices.html
+++ b/Scaling-Accessibility-Practices.html
@@ -70,7 +70,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Training-Team.html
+++ b/Training-Team.html
@@ -70,7 +70,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Walmart-Celebrity-Shopping-Carts.html
+++ b/Walmart-Celebrity-Shopping-Carts.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Wavebooker-Luxury-Rental-Dashboard.html
+++ b/Wavebooker-Luxury-Rental-Dashboard.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/Wedding-Materials-Design.html
+++ b/Wedding-Materials-Design.html
@@ -34,7 +34,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/ai-chatbot-scaling.html
+++ b/ai-chatbot-scaling.html
@@ -70,7 +70,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/chatbot-audit.html
+++ b/chatbot-audit.html
@@ -70,7 +70,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="index.html#work">Design</a>	
 	  </li>
 		  <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item active">
+	  <li class="nav-item">
 		  <a class="nav-link px-3" href="#work">Design</a>
 	  </li>
 		  <li class="nav-item">


### PR DESCRIPTION
Drop the "active" class from the Design nav-item across all pages so it no longer renders bolder than Experience/About - the Experience section itself is untouched.