### PR TITLE
Restyle intro copy, relocate CTA under Projects, resume-ify Experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,16 +63,14 @@
 			<p align="center">emma healy</p>	
 		</div>
 		<div class="col-xl-4 col-lg-3 col-sm-2 col-xs-3"></div>
-		<div class="col-12 vspace1em"></div>
+		<div class="col-12 vspace6em"></div>
     	<div class="intro-copy text-col" data-aos="fade-up" data-aos-once="true">
 			<div class="midlight orangetext">
 				<p>Senior Product Designer at Alpha Omega</p>
 			</div>
 			<div class="vspacehalfem"></div>
-			<p>Specializing in enterprise-grade tools, dashboards, and accessibility.</p>
-			<p>Leading end-to-end design, from user research to high-fidelity Figma prototyping, to create scalable solutions that impact thousands of users daily.</p>
-			<div class="vspacehalfem"></div>
-			<p>Take a look at some sample projects below. Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>
+			<p>Specializing in enterprise-grade tools, dashboards, and accessibility</p>
+			<p>Leading end-to-end design, from user research to high-fidelity Figma prototyping, to create scalable solutions that impact thousands of users daily</p>
 			<div class="vspacehalfem"></div>
 			<p>
 				<a href="mailto:emmahealy2021@u.northwestern.edu">Email<i class="bi bi-arrow-up-right-square ml-1 mr-3" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true"></i></a><a href="https://www.linkedin.com/in/emma-g-healy/" target="_blank">LinkedIn<i class="bi bi-arrow-up-right-square ml-1" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true"></i></a>
@@ -87,6 +85,11 @@
 	<div class="row mx-4" id="work">
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 class="rock-heading">Projects</h1>
+			<div class="col-12 vspace1em"></div>
+			<div class="project-intro">
+				<span class="project-asterisk" aria-hidden="true">*</span>
+				<p id="whitetext">Take a look at some sample projects below. Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>
+			</div>
 		</div>
 	</div>
 	<!--white space-->
@@ -277,6 +280,7 @@
 			<h1 class="rock-heading">Experience</h1>
 			<div class="col-12 vspace2em"></div>
 			<div class="accent-bar">
+				<div class="resume-subheading">Experience</div>
 				<div class="exp-row">
 					<span id="whitetext" class="role">Alpha Omega &mdash; Senior Product Designer</span>
 					<span class="exp-dates">2023&ndash;Present</span>
@@ -286,11 +290,13 @@
 					<span id="whitetext" class="role">Publicis Sapient &mdash; UX Designer</span>
 					<span class="exp-dates">2021&ndash;2023</span>
 				</div>
-				<div class="vspace1em col-12"></div>
+				<div class="vspace2em col-12"></div>
+				<div class="resume-subheading">Certifications</div>
 				<div class="exp-row">
 					<span id="whitetext" class="role">Section 508 Trusted Tester Certification</span>
 				</div>
-				<div class="vspace1em col-12"></div>
+				<div class="vspace2em col-12"></div>
+				<div class="resume-subheading">Education</div>
 				<div class="exp-row">
 					<span id="whitetext" class="role">Northwestern University &mdash; B.S. in Communication Studies, Design, and Marketing</span>
 					<span class="exp-dates">2021</span>

--- a/new_custom.css
+++ b/new_custom.css
@@ -224,6 +224,28 @@ div.vspace8em {
 	color: rgba(255, 255, 255, 0.75);
 	white-space: nowrap;
 }
+.resume-subheading {
+	font-family: 'Josefin Sans', sans-serif;
+	font-weight: 600;
+	font-size: 0.85rem;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: rgba(255, 255, 255, 0.5);
+	margin-bottom: 0.5rem;
+}
+.project-intro {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.85rem;
+	text-align: left;
+}
+.project-asterisk {
+	font-family: "Rock 3D", cursive;
+	font-size: 2.25rem;
+	line-height: 1;
+	color: #fa935c;
+	flex: 0 0 auto;
+}
 .intro-copy,
 .accent-bar {
 	position: relative;


### PR DESCRIPTION
Intro block:
- Doubled the gap between the hero wordmark and the intro text (vspace1em -> vspace6em, per two follow-up requests to push it further).
- Dropped trailing periods from the two descriptor sentences.
- Removed the "Take a look at some sample projects..." paragraph from here entirely.

Projects section:
- Added that relocated paragraph directly under the "Projects" H1, paired with a decorative asterisk in the same Rock 3D heading font/ color (.project-asterisk) sitting to its left.

Experience section:
- Added "Experience" / "Certifications" / "Education" sub-headings (.resume-subheading: small, uppercase, muted) so the section reads as a proper mini-resume instead of one flat list, with the Section 508 Trusted Tester certification and Northwestern B.S. grouped under their own headings.