### PR TITLE
Remove teal accent bar from intro and About, keep it on Experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 		</div>
 		<div class="col-xl-3 col-lg-2 col-sm-1 col-xs-1"></div>
 		<div class="col-12 vspace1em"></div>
-    	<div class="intro-copy text-col" data-aos="fade-up" data-aos-once="true">
+    	<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<div class="midlight orangetext">
 				<p>Senior Product Designer at Alpha Omega</p>
 			</div>
@@ -316,7 +316,7 @@
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
 			<h1 class="rock-heading">About</h1>
 			<div class="col-12 vspace2em"></div>
-			<div class="accent-bar">
+			<div>
 	            <p id="whitetext">My name is Emma Healy, and I'm a Senior Product Designer based in the New York metro. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm also a certified Section 508 expert, experienced in QA testing and training teams to create accessible products. For the past two years, I have been designing improvements to a large federal agency's case management system on an embedded contract at Alpha Omega.</p>
 				<div class="vspace1em col-12"></div>
 				<p id="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries. I graduated from Northwestern University in 2021 with a degree in Communications, Design, and Marketing.</p>

--- a/new_custom.css
+++ b/new_custom.css
@@ -254,12 +254,10 @@ div.vspace8em {
 	line-height: 1;
 	color: #fa935c;
 }
-.intro-copy,
 .accent-bar {
 	position: relative;
 	padding-left: 2.75rem;
 }
-.intro-copy::before,
 .accent-bar::before {
 	content: "";
 	position: absolute;


### PR DESCRIPTION
.accent-bar's CSS previously applied to .intro-copy too (shared selector); split it into its own rule and dropped the intro-copy class from the hero intro block plus the accent-bar class from the About paragraphs, so only Experience keeps the bar + left padding.