### PR TITLE
Decouple Projects asterisk position from paragraph text alignment

### DIFF
--- a/new_custom.css
+++ b/new_custom.css
@@ -242,11 +242,10 @@ div.vspace8em {
 }
 .project-intro {
 	position: relative;
-	padding-left: 2.75rem;
 }
 .project-asterisk {
 	position: absolute;
-	left: 0;
+	left: -2.5rem;
 	top: 50%;
 	transform: translateY(-50%);
 	font-family: "Rock 3D", cursive;


### PR DESCRIPTION
Drop .project-intro's padding-left (which reserved gutter space for the asterisk, pushing the text right) and instead position the asterisk with a negative left offset so it floats outside the text's box. The paragraph now starts flush left, matching the intro block's text above (verified equal left offsets via getBoundingClientRect).