### PR TITLE
Accessibility audit: add missing ARIA labels and semantics

### DIFF
--- a/Walmart-Celebrity-Shopping-Carts.html
+++ b/Walmart-Celebrity-Shopping-Carts.html
@@ -121,7 +121,7 @@
         </div>
         <div class="col-md-7 col-xs-12" data-aos="fade-up" data-aos-once="true">
             <p>Walmart partnered with NFL star Patrick Mahomes, Grammy-nominated artist Becky G, and iconic Barbie to create a digital-first shopping experience featuring curated celebrity shopping carts. I designed the visual interface and marketing materials that brought these three distinct brand personalities together under Walmart's umbrella while maintaining each celebrity's unique aesthetic.</p>
-            <p>Read more about the project from <a class="secondary-link" href="https://corporate.walmart.com/news/2023/07/12/patrick-mahomes-becky-g-and-barbie-inspire-new-ways-to-shop-their-favorite-products" target="_blank">Walmart's VP of Brand Strategy &amp; Marketing<i class="bi bi-arrow-up-right-square ml-1" style="color: #17498F; font-size: 1rem" data-aos="fade-up" data-aos-once="true"></i></a></p>
+            <p>Read more about the project from <a class="secondary-link" href="https://corporate.walmart.com/news/2023/07/12/patrick-mahomes-becky-g-and-barbie-inspire-new-ways-to-shop-their-favorite-products" target="_blank" rel="noopener noreferrer">Walmart's VP of Brand Strategy &amp; Marketing<span class="sr-only"> (opens in new tab)</span><i class="bi bi-arrow-up-right-square ml-1" style="color: #17498F; font-size: 1rem" data-aos="fade-up" data-aos-once="true" aria-hidden="true"></i></a></p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="vspace3em col-12"></div>

--- a/case-study-gate.js
+++ b/case-study-gate.js
@@ -25,13 +25,16 @@
 	function buildGate() {
 		var overlay = document.createElement("div");
 		overlay.className = "gate-overlay";
+		overlay.setAttribute("role", "dialog");
+		overlay.setAttribute("aria-modal", "true");
+		overlay.setAttribute("aria-labelledby", "gate-title");
 		overlay.innerHTML =
 			'<div class="gate-panel">' +
-			'<h2 class="gate-title">Password Protected</h2>' +
+			'<h2 class="gate-title" id="gate-title">Password Protected</h2>' +
 			'<p class="gate-subtext">This case study is password protected. Enter the password to continue.</p>' +
 			'<form class="gate-form" autocomplete="off">' +
 			'<input type="password" class="gate-input" autocomplete="new-password" placeholder="Password" aria-label="Password">' +
-			'<div class="gate-error" hidden>Incorrect password. Please try again.</div>' +
+			'<div class="gate-error" role="alert" hidden>Incorrect password. Please try again.</div>' +
 			'<div class="gate-actions">' +
 			'<a href="index.html" class="gate-cancel">Back to homepage</a>' +
 			'<button type="submit" class="gate-submit">Unlock</button>' +
@@ -39,6 +42,11 @@
 			"</form>" +
 			"</div>";
 		document.body.appendChild(overlay);
+		Array.prototype.forEach.call(document.body.children, function (el) {
+			if (el !== overlay) {
+				el.setAttribute("inert", "");
+			}
+		});
 		return overlay;
 	}
 
@@ -62,6 +70,9 @@
 			e.preventDefault();
 			sha256Hex(input.value).then(function (hash) {
 				if (hash === PASSWORD_HASH) {
+					Array.prototype.forEach.call(document.body.children, function (el) {
+						el.removeAttribute("inert");
+					});
 					overlay.remove();
 					sessionStorage.setItem(STORAGE_KEY, "true");
 					return;

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 			<p>Leading end-to-end design to create scalable solutions that impact thousands of daily users</p>
 			<div class="vspacehalfem"></div>
 			<p>
-				<a href="mailto:emmahealy2021@u.northwestern.edu">Email<i class="bi bi-arrow-up-right-square ml-1 mr-3" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true"></i></a><a href="https://www.linkedin.com/in/emma-g-healy/" target="_blank">LinkedIn<i class="bi bi-arrow-up-right-square ml-1" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true"></i></a>
+				<a href="mailto:emmahealy2021@u.northwestern.edu">Email<i class="bi bi-arrow-up-right-square ml-1 mr-3" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true" aria-hidden="true"></i></a><a href="https://www.linkedin.com/in/emma-g-healy/" target="_blank" rel="noopener noreferrer">LinkedIn<span class="sr-only"> (opens in new tab)</span><i class="bi bi-arrow-up-right-square ml-1" style="color: #b7e6e1; font-size: 1rem" data-aos="fade-up" data-aos-once="true" aria-hidden="true"></i></a>
 			</p>
 		</div>
 	</div>
@@ -99,13 +99,13 @@
 	<!--category filter-->
 	<div class="row mx-4">
 		<div class="filter-bar" role="group" aria-label="Filter projects by category">
-			<button type="button" class="filter-btn active" data-filter="all">All</button>
-			<button type="button" class="filter-btn" data-filter="strategy">Strategy</button>
-			<button type="button" class="filter-btn" data-filter="research">Research</button>
-			<button type="button" class="filter-btn" data-filter="ux">UX</button>
-			<button type="button" class="filter-btn" data-filter="usability-testing">Usability Testing</button>
-			<button type="button" class="filter-btn" data-filter="ui">UI</button>
-			<button type="button" class="filter-btn" data-filter="data-visualization">Data Visualization</button>
+			<button type="button" class="filter-btn active" data-filter="all" aria-pressed="true">All</button>
+			<button type="button" class="filter-btn" data-filter="strategy" aria-pressed="false">Strategy</button>
+			<button type="button" class="filter-btn" data-filter="research" aria-pressed="false">Research</button>
+			<button type="button" class="filter-btn" data-filter="ux" aria-pressed="false">UX</button>
+			<button type="button" class="filter-btn" data-filter="usability-testing" aria-pressed="false">Usability Testing</button>
+			<button type="button" class="filter-btn" data-filter="ui" aria-pressed="false">UI</button>
+			<button type="button" class="filter-btn" data-filter="data-visualization" aria-pressed="false">Data Visualization</button>
 		</div>
 	</div>
 	<!--white space-->
@@ -324,7 +324,7 @@
 				<div class="vspace1em col-12"></div>
 				<p id="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries.</p>
 				<div class="vspace1em col-12"></div>
-	            <p id="whitetext">When I remember to look up from my laptop, I take classes. Sometimes oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem"></i></a> in West Village. I'm a novice gardener and truly terrible tennis player.</p>
+	            <p id="whitetext">When I remember to look up from my laptop, I take classes. Sometimes oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in West Village. I'm a novice gardener and truly terrible tennis player.</p>
 				<div class="vspace1em col-12"></div>
 				<p id="whitetext">That's me! Thanks for stopping by.</p>
 			</div>
@@ -348,7 +348,9 @@
 
             function applyFilter(filter) {
                 filterButtons.forEach(function (b) {
-                    b.classList.toggle('active', b.getAttribute('data-filter') === filter);
+                    var isActive = b.getAttribute('data-filter') === filter;
+                    b.classList.toggle('active', isActive);
+                    b.setAttribute('aria-pressed', isActive ? 'true' : 'false');
                 });
                 projects.forEach(function (project) {
                     var categories = project.getAttribute('data-categories').split(',');
@@ -404,7 +406,7 @@
                 var el = hash ? document.getElementById(hash) : null;
                 var navItem = link.closest('.nav-item');
                 if (el && navItem) {
-                    sections.push({ el: el, navItem: navItem });
+                    sections.push({ el: el, navItem: navItem, navLink: link });
                 }
             });
             if (!sections.length) return;
@@ -419,6 +421,11 @@
                 });
                 sections.forEach(function (s) {
                     s.navItem.classList.toggle('active', s === current);
+                    if (s === current) {
+                        s.navLink.setAttribute('aria-current', 'true');
+                    } else {
+                        s.navLink.removeAttribute('aria-current');
+                    }
                 });
             }
 


### PR DESCRIPTION
No visual changes; all fixes are ARIA/semantic additions:

- Password gate modal (case-study-gate.js): give the overlay role="dialog", aria-modal="true", and aria-labelledby pointing at the title; mark the rest of the page inert while the gate is up so keyboard/screen-reader users can't tab into hidden content behind it; give the error message role="alert" so it's announced when a wrong password is entered.
- Filter buttons (index.html): add aria-pressed, kept in sync by the existing filter JS, so screen reader users can tell which category filter is currently selected (the state was previously conveyed by a CSS class only).
- Scrollspy nav (index.html): add aria-current="true" to the link matching the section in view, mirroring the existing visual active-state.
- Decorative external-link arrow icons (index.html, Walmart page): add aria-hidden="true" so screen readers don't announce icon-font glyphs redundantly next to the link's own visible text.
- The two target="_blank" links (LinkedIn, Walmart press link): add rel="noopener noreferrer" and a visually-hidden "(opens in new tab)" cue for screen reader users.