### PR TITLE
Accessibility: visible focus ring on password input, respect reduced-…

### DIFF
--- a/new_custom.css
+++ b/new_custom.css
@@ -569,6 +569,7 @@ a:hover {
 }
 .gate-input:focus {
 	border-color: #fa935c;
+	box-shadow: 0 0 0 3px rgba(250, 147, 92, 0.4);
 }
 .gate-error {
 	font-family: "Josefin Sans", sans-serif;
@@ -683,4 +684,11 @@ section {
 	filter: drop-shadow(-1px 1px 4px #f8f0e3);
 	/*filter: drop-shadow(1px -1px 2px #f8f0e3) drop-shadow(-15px 15px #fa935c); */
 
+}
+@media (prefers-reduced-motion: reduce) {
+	[data-aos] {
+		transition: none !important;
+		transform: none !important;
+		opacity: 1 !important;
+	}
 }


### PR DESCRIPTION
…motion

The password gate's input suppressed the default focus outline (outline: none) and relied on a subtle 1px border-color change as the only focus indicator - add a focus ring alongside it for a clearer WCAG 2.4.7 focus indicator.

AOS's scroll-in animations never checked the OS-level "reduce motion" preference. Add a prefers-reduced-motion media query that disables the fade/transform for users who've opted into reduced motion at the OS level; everyone else's experience is unchanged.