### PR TITLE
Fix duplicate IDs, low-contrast text, and add a skip-to-content link

### DIFF
--- a/Content-Shortcuts.html
+++ b/Content-Shortcuts.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -54,7 +55,7 @@
          <img src="/Images/PDF-Management-App/hero-image.png" alt="Rendering of a mid-fidelity PDF Editor UI">
 	</div>
 </section>-->
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space--> 
         <div class="row mx-4">
                 <div class="col-12 vspace3em"></div>
@@ -205,7 +206,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12 ">
             <h4>Key Research Findings</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Users span multiple career levels with different priorities and preferred ways of working.</strong></p>
             <p>Some users scrolled through files, from Page 1 to the end, for a cursory skim before going back to review in detail.  Some preferred to flag pages of interest using thumbnails without the full read-through.  Others spent time messaging back-and-forth with their direct reports to discuss the documents.</p>
@@ -213,14 +214,14 @@
             <!--<p>Each user expressed distinct preferences and workflows, which presented interesting design challenges and required our team to prioritize flexibility.  While some were interested in features like filters, others tended to resent extra visual noise on their screens.</p>-->
             <div class="vspacehalfem col-12"></div>
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>AI tagging was underutilized and unrecognizable from manual tags.</strong></p>
             <p>Users reviewed, annotated, flagged, and approved anywhere from 10 to 40 pages of documents at once.  Those documents ranged from driver’s licenses to federal forms to doctor’s notes.  Users referred to specific pages of evidence multiple times and scrolled back and forth between pages often.  Users could always tag pages with document labels, but had not yet worked with AI tagging.  </p>
             <p>Users were unaware of new AI features and could not tell the difference between manually and AI-generated document tags.</p>
             <div class="vspacehalfem col-12"></div>
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>The manual tagging flow was simply too cumbersome.</strong></p>
             <p>Users had to choose tags from a single-select dropdown with hundreds of potential tags and no typeahead.  Understandably, they preferred to leave the comment “driver’s license” rather than scroll through the dropdown to tag.  We knew that we had to fix the tagging pattern to get value out of the new AI tags.</p>
@@ -428,7 +429,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Significantly improved navigation performance</strong> in usability testing</p>
         </div>
@@ -436,7 +437,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Established AI design patterns </strong>for future client tools</p>
         </div>
@@ -444,7 +445,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Reduced user frustration</strong> with commenting and tagging workflows</p>
         </div>
@@ -452,7 +453,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Created scalable design system</strong> with dark mode capabilities</p>
         </div>

--- a/Invesco-Cloud-Dashboard.html
+++ b/Invesco-Cloud-Dashboard.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -53,7 +54,7 @@
         <img src="/Images/Invesco-Cloud-Dashboard/hero-image.png" alt="Rendering of the Invesco cloud usage dashboard">
 	</div>
 </section>
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space-->    
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>
@@ -157,7 +158,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">01.</p>
+            <p class="redtext">01.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -170,7 +171,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">02.</p>
+            <p class="redtext">02.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -183,7 +184,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">03.</p>
+            <p class="redtext">03.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -196,7 +197,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">04.</p>
+            <p class="redtext">04.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -326,7 +327,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">01.</p>
+            <p class="redtext">01.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -339,7 +340,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">02.</p>
+            <p class="redtext">02.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -352,7 +353,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">03.</p>
+            <p class="redtext">03.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -365,7 +366,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">04.</p>
+            <p class="redtext">04.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>

--- a/PDF-Management-App.html
+++ b/PDF-Management-App.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -54,7 +55,7 @@
          <img src="/Images/PDF-Management-App/hero-image.png" alt="Rendering of a mid-fidelity PDF Editor UI">
 	</div>
 </section>
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space--> 
         <div class="row mx-4">
                 <div class="col-12 vspace3em"></div>
@@ -205,7 +206,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12 ">
             <h4>Key Research Findings</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Users span multiple career levels with different priorities and preferred ways of working.</strong></p>
             <p>Some users scrolled through files, from Page 1 to the end, for a cursory skim before going back to review in detail.  Some preferred to flag pages of interest using thumbnails without the full read-through.  Others spent time messaging back-and-forth with their direct reports to discuss the documents.</p>
@@ -213,14 +214,14 @@
             <!--<p>Each user expressed distinct preferences and workflows, which presented interesting design challenges and required our team to prioritize flexibility.  While some were interested in features like filters, others tended to resent extra visual noise on their screens.</p>-->
             <div class="vspacehalfem col-12"></div>
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>AI tagging was underutilized and unrecognizable from manual tags.</strong></p>
             <p>Users reviewed, annotated, flagged, and approved anywhere from 10 to 40 pages of documents at once.  Those documents ranged from driver’s licenses to federal forms to doctor’s notes.  Users referred to specific pages of evidence multiple times and scrolled back and forth between pages often.  Users could always tag pages with document labels, but had not yet worked with AI tagging.  </p>
             <p>Users were unaware of new AI features and could not tell the difference between manually and AI-generated document tags.</p>
             <div class="vspacehalfem col-12"></div>
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>The manual tagging flow was simply too cumbersome.</strong></p>
             <p>Users had to choose tags from a single-select dropdown with hundreds of potential tags and no typeahead.  Understandably, they preferred to leave the comment “driver’s license” rather than scroll through the dropdown to tag.  We knew that we had to fix the tagging pattern to get value out of the new AI tags.</p>
@@ -429,7 +430,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Significantly improved navigation performance</strong> in usability testing</p>
         </div>
@@ -437,7 +438,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Established AI design patterns </strong>for future client tools</p>
         </div>
@@ -445,7 +446,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Reduced user frustration</strong> with commenting and tagging workflows</p>
         </div>
@@ -453,7 +454,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Created scalable design system</strong> with dark mode capabilities</p>
         </div>

--- a/Scaling-Accessibility-Practices.html
+++ b/Scaling-Accessibility-Practices.html
@@ -27,6 +27,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
     <script src="case-study-gate.js" defer></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -55,7 +56,7 @@
          <img src="/Images/training-team/Hero%20Image.png" alt="Rendering of a Learning Management System homepage">
 	</div>
 </section>-->
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space-->
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>
@@ -270,7 +271,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Delivered accessibility workshops</strong> that introduced 12 product teams to auditor-grade testing tools and techniques—building a consistent, shared baseline of accessibility knowledge across the program for the first time</p>
         </div>
@@ -278,7 +279,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Piloted a scalable design-to-dev handoff model</strong> using Figma Dev Mode to embed ARIA labels and accessibility annotations directly in code snippets, reducing handoff gaps that had contributed to repeated implementation failures</p>
         </div>
@@ -286,7 +287,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Contributed lasting documentation</strong> to shared Storybook component libraries in both Ruby and React, giving all teams persistent, implementation-ready accessibility guidance for every shared component</p>
         </div>
@@ -294,7 +295,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Shifted the program's accessibility culture</strong> from reactive remediation toward proactive design practice, enabling teams to catch and address issues within their own sprint cycle rather than waiting for external audit cycles to surface them</p>
         </div>

--- a/Training-Team.html
+++ b/Training-Team.html
@@ -27,6 +27,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
     <script src="case-study-gate.js" defer></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -55,7 +56,7 @@
          <img src="/Images/training-team/Hero%20Image.png" alt="Rendering of a Learning Management System homepage">
 	</div>
 </section>
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space-->
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>
@@ -376,7 +377,7 @@
             <p>Based on our research findings, we designed and shipped a functional and scalable Learning Management System in three months that addressed each major pain point we had identified.</p>
             <p>The LMS enables trainers to:</p>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Create and manage classrooms</strong> with dedicated training environments</p>
         </div>
@@ -384,7 +385,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Verify learner access to crucial systems</strong> before training begins</p>
         </div>
@@ -392,7 +393,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Assign realistic practices cases</strong> that can be taken through complete workflows</p>
         </div>
@@ -400,7 +401,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Manage assignments</strong> and track trainee progress through essential job functions</p>
         </div>
@@ -462,7 +463,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Successfully pitched leadership</strong> to create an entirely new product team from a single application insight</p>
         </div>
@@ -470,7 +471,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Established scalable training infrastructure</strong> serving 10+ cross-functional teams</p>
         </div>
@@ -478,7 +479,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Delivered a working LMS in just 3 months</strong> that addressed core training challenges</p>
         </div>
@@ -486,7 +487,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Created sustainable frameworks</strong> for ongoing technical enablement across the program</p>
         </div>
@@ -494,7 +495,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">05.</p>
+                <p class="redtext">05.</p>
             </div>
             <p><strong>Improved trainer confidence</strong> and effectiveness through better tools and environments</p>
         </div>

--- a/Walmart-Celebrity-Shopping-Carts.html
+++ b/Walmart-Celebrity-Shopping-Carts.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -53,7 +54,7 @@
          <img src="/Images/Walmart-Celebrity-Carts/hero-image.png" alt="Rendering of a laptop with Barbie logo and photos. Barbie plays pickleball in a pink outfit.">
 	</div>
 </section>
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space--> 
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>

--- a/Wavebooker-Luxury-Rental-Dashboard.html
+++ b/Wavebooker-Luxury-Rental-Dashboard.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -54,7 +55,7 @@
          <img src="/Images/PDF-Management-App/hero-image.png" alt="Rendering of a mid-fidelity PDF Editor UI">
 	</div>
 </section>-->
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space--> 
         <div class="row mx-4">
                 <div class="col-12 vspace3em"></div>
@@ -148,7 +149,7 @@
                 <p>Small luxury boat rental operators were drowning in operational overhead. Most relied on homegrown WordPress sites that were difficult to maintain and lacked the polish their clientele expected. These business owners are too busy running their operations to worry about website design, SEO, or user experience—but they knew their digital presence was costing them customers.</p>
                 <p>The pain points were clear:</p>
                 <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Fragmented touchpoints:</strong> Customers had to call to get basic information about their rental, creating friction in the booking process</p>
         </div>
@@ -156,7 +157,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Unprofessional appearance:</strong> DIY websites didn't match the luxury experience owners wanted to provide</p>
         </div>
@@ -164,7 +165,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Disconnected systems:</strong> Separate tools for listings, bookings, and communication meant nothing talked to each other</p>
         </div>
@@ -172,7 +173,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Lost revenue:</strong> Owners suspected they were losing bookings to competitors with more polished digital experiences</p>
         </div>
@@ -326,7 +327,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>Significantly improved navigation performance</strong> in usability testing</p>
         </div>
@@ -334,7 +335,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p><strong>Established AI design patterns </strong>for future client tools</p>
         </div>
@@ -342,7 +343,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p><strong>Reduced user frustration</strong> with commenting and tagging workflows</p>
         </div>
@@ -350,7 +351,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p><strong>Created scalable design system</strong> with dark mode capabilities</p>
         </div>

--- a/Wedding-Materials-Design.html
+++ b/Wedding-Materials-Design.html
@@ -26,6 +26,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -57,7 +58,7 @@
          <img src="/Images/PDF-Management-App/hero-image.png" alt="Rendering of a mid-fidelity PDF Editor UI">
 	</div>-->
 </section>
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space--> 
         <div class="row mx-4">
                 <div class="col-12 vspace3em"></div>

--- a/ai-chatbot-scaling.html
+++ b/ai-chatbot-scaling.html
@@ -27,6 +27,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
     <script src="case-study-gate.js" defer></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -55,7 +56,7 @@
          <img src="/Images/training-team/Hero%20Image.png" alt="Rendering of a Learning Management System homepage">
 	</div>
 </section>-->
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space-->
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>
@@ -288,7 +289,7 @@
         <div class="col-xl-6 col-md-8 col-xs-12">
             <h4>Key Achievements</h4>
             <div class="highlight">
-                <p id="redtext">01.</p>
+                <p class="redtext">01.</p>
             </div>
             <p><strong>2,000 employees</strong> completed mandatory multi-day investigative interview training through the tool over three months—the first time an AI-powered training product had been deployed at this scale within the agency.</p>
         </div>
@@ -296,7 +297,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">02.</p>
+                <p class="redtext">02.</p>
             </div>
             <p>Designed a <strong>five-level difficulty system</strong> that ranged from a fully cooperative interview subject at Level 1 to an evasive, deceptive interviewee at Level 5—giving employees a self-directed path through a skill curve that matched their experience, with the freedom to advance when ready.</p>
         </div>
@@ -304,7 +305,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">03.</p>
+                <p class="redtext">03.</p>
             </div>
             <p>Solved a <strong>novel deception design problem</strong> through iterative testing—identifying that numerical and temporal fabrications produced reliable, plausible falsehoods that genuinely tested employees' ability to spot inconsistencies, while complex conceptual or geographic deception broke down under scrutiny.</p>
         </div>
@@ -312,7 +313,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">04.</p>
+                <p class="redtext">04.</p>
             </div>
             <p>Reduced costs and improved performance to make the product viable at scale—negotiating cohort sizes with stakeholders, stripping prompt redundancy without sacrificing behavioral fidelity, and implementing <strong>live streaming output</strong> so response latency felt like natural conversation rather than system delay.</p>
         </div>
@@ -320,7 +321,7 @@
         <div class="col-xl-3 col-md-2 col-xs-12"></div>
         <div class="col-xl-6 col-md-8 col-xs-12">
             <div class="highlight">
-                <p id="redtext">05.</p>
+                <p class="redtext">05.</p>
             </div>
             <p>Delivered an <strong>admin configuration layer</strong> and a reusable set of leveled conversation UX patterns that gave training program owners operational independence and established a foundation for future AI-powered training programs within the agency.</p>
         </div>

--- a/chatbot-audit.html
+++ b/chatbot-audit.html
@@ -27,6 +27,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.js"></script>
     <script src="case-study-gate.js" defer></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom-bg" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -54,7 +55,7 @@
          <img src="/Images/PDF-Management-App/hero-image.png" alt="Rendering of a mid-fidelity PDF Editor UI">
 	</div>
 </section> -->
-<main style="background-color: #FFFDF7" class="container-fluid">
+<main id="main-content" tabindex="-1" style="background-color: #FFFDF7" class="container-fluid">
 <!--white space-->
     <div class="row mx-4">
 		<div class="col-12 vspace3em"></div>
@@ -67,14 +68,14 @@
 		<div class="col-xl-3 col-lg-2 col-md-1 col-sm-2 col-xs-2"></div>
 		<div class="col-xl-5 col-lg-6 col-md-6 col-sm-6 col-xs-10">
 			<div class="vspacehalfem"></div>
-			<h7 class="pl-4" id=whitetext>RAIO - Password Protected</h7>
+			<h7 class="pl-4 whitetext">RAIO - Password Protected</h7>
 			<div class="vspacehalfem"></div>
 			<h4 class="pl-4" type="link-primary" class=link-primary>
 				<a href="AI-Chatbot-Redesign.html">AI Chatbot Interface Redesign</a>
 			</h4>
 			<div class="vspacehalfem"></div>
-			<p class="pl-4" id=whitetext><strong></strong>Enhanced conversational UI experiences for Claude Opus-powered chatbot through improved accessibility, streamlined chat transcript downloads, and optimized interaction flows. Contributed to response strategy decisions that increased user satisfaction.</p>
-			<h7 class="pl-4" id=whitetext>UX Design // Conversation Design // Accessibility</h7>
+			<p class="pl-4 whitetext"><strong></strong>Enhanced conversational UI experiences for Claude Opus-powered chatbot through improved accessibility, streamlined chat transcript downloads, and optimized interaction flows. Contributed to response strategy decisions that increased user satisfaction.</p>
+			<h7 class="pl-4 whitetext">UX Design // Conversation Design // Accessibility</h7>
 		</div>
 		<div class="col-xl-2 col-lg-3 col-md-4 col-sm-3 col-xs-8" data-aos="fade-up" data-aos-once="true">
 			<a href="AI-Chatbot-Redesign.html"><img class="img-fluid float-right rounded-lg p-r-5" src="Images/Secondary%20Logo%20Block.png" alt="Placeholder" data-aos="fade-up" data-aos-once="true"></a>
@@ -227,7 +228,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">01.</p>
+            <p class="redtext">01.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -240,7 +241,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">02.</p>
+            <p class="redtext">02.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
@@ -253,7 +254,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">03.</p>
+            <p class="redtext">03.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div><div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12">
@@ -265,7 +266,7 @@
         <div class="col-md-1 col-xs-12"></div>
         <div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12 highlight">
-            <p id="redtext">04.</p>
+            <p class="redtext">04.</p>
         </div>
         <div class="col-md-1 col-xs-12"></div><div class="col-md-4 col-xs-12"></div>
         <div class="col-md-7 col-xs-12">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 	<script src="one_sketch_to_rule_them_all.js"></script>
 	<script src="my_js.js"></script>
 </head>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <header>
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark navbar-custom" data-mdb-navbar-init>
 	  <a class="navbar-brand ml-3" href="index.html">Emma Healy</a>
@@ -49,7 +50,7 @@
 	  </div>
 	</nav>
 </header>
-<main style="background-color: #0a2243">
+<main id="main-content" tabindex="-1" style="background-color: #0a2243">
 <div class="content-wrap">
 	<!--white space-->
 	<div class="row mx-4">
@@ -88,7 +89,7 @@
 			<div class="col-12 vspace1em"></div>
 			<div class="project-intro">
 				<span class="project-asterisk" aria-hidden="true">*</span>
-				<p id="whitetext">Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>
+				<p class="whitetext">Much of my recent work is confidential, so feel free to reach out if you'd like to hear more about it.</p>
 			</div>
 		</div>
 	</div>
@@ -118,15 +119,15 @@
 		<div class="project-compact" data-aos="fade-up" data-aos-once="true">
 			<div class="project-text-inner">
 				<div class="lowlight">
-					<p id=whitetext>FEDERAL AGENCY - Password Protected</p>
+					<p class="whitetext">FEDERAL AGENCY - Password Protected</p>
 				</div>
 				<h4 type="link-primary" class=link-primary>
 					<a href="ai-chatbot-scaling.html">Scaling an AI Training Chatbot Across a Government Agency</a>
 				</h4>
 				<div class="vspacehalfem"></div>
-				<p id=whitetext>Scaled a proof-of-concept training chatbot to meet an agency-wide training demand, improving conversation UX, onboarding flow, and cost optimization.</p>
+				<p class="whitetext">Scaled a proof-of-concept training chatbot to meet an agency-wide training demand, improving conversation UX, onboarding flow, and cost optimization.</p>
 				<div class="lowlight">
-					<p id=whitetext>Conversation Design // Product Strategy</p>
+					<p class="whitetext">Conversation Design // Product Strategy</p>
 				</div>
 			</div>
 		</div>
@@ -138,15 +139,15 @@
 		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
 			<div class="vspacehalfem"></div>
 			<div class="lowlight">
-				<p class="px-4" id=whitetext>FEDERAL AGENCY - Password Protected</p>
+				<p class="px-4 whitetext">FEDERAL AGENCY - Password Protected</p>
 			</div>
 			<h4 class="px-4" type="link-primary" class=link-primary>
 				<a href="Scaling-Accessibility-Practices.html">Scaling Accessibility Practices Across a Lean Product Program</a>
 			</h4>
 			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Facilitated accessibility workshops, reviewed designs for accessibility, and contributed shared component documentation.</p>
+			<p class="px-4 whitetext">Facilitated accessibility workshops, reviewed designs for accessibility, and contributed shared component documentation.</p>
 			<div class="lowlight">
-				<p class="px-4" id=whitetext>Accessibility // Product Strategy</p>
+				<p class="px-4 whitetext">Accessibility // Product Strategy</p>
 			</div>
 		</div>
 		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line
@@ -165,13 +166,13 @@
 			<a href="Training-Team.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/training-team-thumbnail.png" alt="A learning management system interface"></a>
 			<div class="project-text-inner">
 				<div class="lowlight">
-					<p id=whitetext>FEDERAL AGENCY - Password Protected</p>
+					<p class="whitetext">FEDERAL AGENCY - Password Protected</p>
 				</div>
 				<h4 type="link-primary" class=link-primary>
 					<a href="Training-Team.html">Leading an Enterprise Training &amp; Enablement Initiative</a>
 				</h4>
 				<div class="vspacehalfem"></div>
-				<p id=whitetext>Identified critical training gap and won stakeholder buy-in for new product team. Developed strategic proposal that secured resources for ongoing technical enablement.</p>
+				<p class="whitetext">Identified critical training gap and won stakeholder buy-in for new product team. Developed strategic proposal that secured resources for ongoing technical enablement.</p>
 				<div class="tag-list">
 					<button type="button" class="tag-pill" data-filter="strategy">Strategy</button>
 					<button type="button" class="tag-pill" data-filter="research">Research</button>
@@ -186,13 +187,13 @@
 			<a href="PDF-Management-App.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/pdf-management-thumbnail.png" alt="A PDF Editor interface"></a>
 			<div class="project-text-inner">
 				<div class="lowlight">
-					<p id=whitetext>FEDERAL AGENCY</p>
+					<p class="whitetext">FEDERAL AGENCY</p>
 				</div>
 				<h4 type="link-primary" class=link-primary>
 					<a href="PDF-Management-App.html">PDF Management App Redesign with AI Components</a>
 				</h4>
 				<div class="vspacehalfem"></div>
-				<p id=whitetext>Led a cross-functional team to redesign a complex enterprise application. Designed new AI tagging tools, improved naviation, and conducted comprehensive user research and testing.</p>
+				<p class="whitetext">Led a cross-functional team to redesign a complex enterprise application. Designed new AI tagging tools, improved naviation, and conducted comprehensive user research and testing.</p>
 				<div class="tag-list">
 					<button type="button" class="tag-pill" data-filter="ux">UX</button>
 					<button type="button" class="tag-pill" data-filter="research">Research</button>
@@ -207,13 +208,13 @@
 			<a href="Invesco-Cloud-Dashboard.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/invesco-cloud-thumbnail.png" alt="An Invesco cloud usage dashboard interface"></a>
 			<div class="project-text-inner">
 				<div class="lowlight">
-					<p id=whitetext>INVESCO</p>
+					<p class="whitetext">INVESCO</p>
 				</div>
 				<h4 type="link-primary" class=link-primary>
 					<a href="Invesco-Cloud-Dashboard.html">Cloud Usage Dashboard</a>
 				</h4>
 				<div class="vspacehalfem"></div>
-				<p id=whitetext>Led UI design for executive dashboard pitched directly to Invesco CFO. Created interactive prototype to visualize complex cloud spending data.</p>
+				<p class="whitetext">Led UI design for executive dashboard pitched directly to Invesco CFO. Created interactive prototype to visualize complex cloud spending data.</p>
 				<div class="tag-list">
 					<button type="button" class="tag-pill" data-filter="ui">UI</button>
 					<button type="button" class="tag-pill" data-filter="data-visualization">Data Visualization</button>
@@ -227,13 +228,13 @@
 			<a href="Walmart-Celebrity-Shopping-Carts.html" class="thumb-link"><img class="rounded-lg thumb-square" src="Images/walmart-celebrity-carts-thumbnail.png" alt="Graphic displaying Walmart Celebrity collaboration photos of Patrick Mahomes, Barbie, and Becky G"></a>
 			<div class="project-text-inner">
 				<div class="lowlight">
-					<p id=whitetext>WALMART</p>
+					<p class="whitetext">WALMART</p>
 				</div>
 				<h4 type="link-primary" class=link-primary>
 					<a href="Walmart-Celebrity-Shopping-Carts.html">Celebrity Shopping Carts</a>
 				</h4>
 				<div class="vspacehalfem"></div>
-				<p id=whitetext>Delivered themed e-commerce assets for Walmart's Q3 celebrity collaborations. Balanced multiple brand identities while maintaining Walmart's design standards.</p>
+				<p class="whitetext">Delivered themed e-commerce assets for Walmart's Q3 celebrity collaborations. Balanced multiple brand identities while maintaining Walmart's design standards.</p>
 				<div class="tag-list">
 					<button type="button" class="tag-pill" data-filter="graphic-design">Graphic Design</button>
 					<button type="button" class="tag-pill" data-filter="ui">UI</button>
@@ -248,15 +249,15 @@
 		<div class="col-xl-5 col-lg-6 col-md-8 col-xs-10">
 			<div class="vspacehalfem"></div>
 			<div class="lowlight">
-				<p class="px-4" id=whitetext>FREELANCE</p>
+				<p class="px-4 whitetext">FREELANCE</p>
 			</div>
 			<h4 class="px-4" type="link-primary" class=link-primary>
 				<a href="Wedding-Materials-Design.html">Wedding Invitation Suite &amp; Event Materials Design</a>
 			</h4>
 			<div class="vspacehalfem"></div>
-			<p class="px-4" id=whitetext>Designed print materials for a wedding, including invitations, menus, and day-of event signage.</p>
+			<p class="px-4 whitetext">Designed print materials for a wedding, including invitations, menus, and day-of event signage.</p>
 			<div class="lowlight">
-				<p class="px-4" id=whitetext>Graphic Design</p>
+				<p class="px-4 whitetext">Graphic Design</p>
 			</div>
 		</div>
 		<div class="d-none d-md-block d-lg-none col-md-2"></div> <!--md margin, break line-->
@@ -281,23 +282,23 @@
 			<div class="accent-bar">
 				<div class="resume-subheading">Experience</div>
 				<div class="exp-row">
-					<span id="whitetext" class="role">Alpha Omega &mdash; Senior Product Designer</span>
+					<span class="role whitetext">Alpha Omega &mdash; Senior Product Designer</span>
 					<span class="exp-dates">2023&ndash;Present</span>
 				</div>
 				<div class="vspace1em col-12"></div>
 				<div class="exp-row">
-					<span id="whitetext" class="role">Publicis Sapient &mdash; UX Designer</span>
+					<span class="role whitetext">Publicis Sapient &mdash; UX Designer</span>
 					<span class="exp-dates">2021&ndash;2023</span>
 				</div>
 				<div class="vspace2em col-12"></div>
 				<div class="resume-subheading">Certifications</div>
 				<div class="exp-row">
-					<span id="whitetext" class="role">Section 508 Trusted Tester Certification</span>
+					<span class="role whitetext">Section 508 Trusted Tester Certification</span>
 				</div>
 				<div class="vspace2em col-12"></div>
 				<div class="resume-subheading">Education</div>
 				<div class="exp-row">
-					<span id="whitetext" class="role">Northwestern University &mdash; B.S. in Communication Studies, Design, and Marketing</span>
+					<span class="role whitetext">Northwestern University &mdash; B.S. in Communication Studies, Design, and Marketing</span>
 					<span class="exp-dates">2021</span>
 				</div>
 			</div>
@@ -320,13 +321,13 @@
 			<h1 class="rock-heading">About</h1>
 			<div class="col-12 vspace2em"></div>
 			<div>
-	            <p id="whitetext">I'm a Senior Product Designer based in the New York metro. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm also a certified Section 508 expert, experienced in QA testing and training teams to create accessible products. For the past three years, I have been designing improvements to a large federal agency's case management system on an embedded contract at Alpha Omega.</p>
+	            <p class="whitetext">I'm a Senior Product Designer based in the New York metro. I love to work on lean, integrated product teams to streamline existing features or create new flows from scratch. I'm also a certified Section 508 expert, experienced in QA testing and training teams to create accessible products. For the past three years, I have been designing improvements to a large federal agency's case management system on an embedded contract at Alpha Omega.</p>
 				<div class="vspace1em col-12"></div>
-				<p id="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries.</p>
+				<p class="whitetext">Before Alpha Omega, I worked as a consultant at Publicis Sapient. My clients included Walmart, Invesco, the Federal Home Loan Bank of New York, and a federal agency. I pitched for new work in the travel and hospitality, financial, and apparel industries.</p>
 				<div class="vspace1em col-12"></div>
-	            <p id="whitetext">When I remember to look up from my laptop, I take classes. Sometimes oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in West Village. I'm a novice gardener and truly terrible tennis player.</p>
+	            <p class="whitetext">When I remember to look up from my laptop, I take classes. Sometimes oil painting at the <a href="https://www.decorusatelier.com/">Decorus Atelier<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in Brooklyn, watercolor at the <a href="https://www.academyeverywhere.com/">New York Academy of Art<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> downtown, or creative writing at the <a href="https://www.writerstudio.com/">Writers Studio<i class="bi bi-arrow-up-right-square ml-1 mr-1" style="color: #b7e6e1; font-size: .8rem" aria-hidden="true"></i></a> in West Village. I'm a novice gardener and truly terrible tennis player.</p>
 				<div class="vspace1em col-12"></div>
-				<p id="whitetext">That's me! Thanks for stopping by.</p>
+				<p class="whitetext">That's me! Thanks for stopping by.</p>
 			</div>
 		</div>
 		<div class="col-12 vspace6em"></div>

--- a/new_custom.css
+++ b/new_custom.css
@@ -5,6 +5,23 @@ p, body {
 	font-size: clamp(1rem, 0.92rem + 0.35vw, 1.1rem);
 	line-height: 1.6;
 }
+.skip-link {
+	position: absolute;
+	top: -60px;
+	left: 0;
+	z-index: 10000;
+	background-color: #fa935c;
+	color: #0a2243;
+	font-family: 'Josefin Sans', sans-serif;
+	font-weight: 600;
+	padding: 0.75rem 1.25rem;
+	text-decoration: none;
+	border-radius: 0 0 0.3rem 0;
+	transition: top 150ms ease;
+}
+.skip-link:focus {
+	top: 0;
+}
 h1, h2 {
 	font-family: 'Josefin Sans', sans-serif;
 	font-weight: 600;
@@ -89,7 +106,7 @@ h7 {
     font-style: italic;
 	font-size: 1.35rem;
 }
-#redtext {
+.redtext {
 	font-family: 'Josefin Sans', sans-serif;
 	font-weight: 700;
 	font-style: normal;
@@ -246,7 +263,7 @@ div.vspace8em {
 	font-size: 0.85rem;
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
-	color: rgba(255, 255, 255, 0.5);
+	color: rgba(255, 255, 255, 0.6);
 	margin-bottom: 0.5rem;
 }
 .project-intro {
@@ -444,7 +461,7 @@ footer {
 }
 .footertext p {
 	font-size: 0.9rem;
-	color: rgba(255, 255, 255, 0.45);
+	color: rgba(255, 255, 255, 0.6);
 }
 .footerhighlight p {
 	font-size: 1.4rem;
@@ -455,9 +472,6 @@ footer {
 }
 #blacktext {
     color: #141A18;
-}
-#whitetext {
-    color: #FFFFFF;
 }
 .whitetext {
 	color: #FFFFFF;


### PR DESCRIPTION
Duplicate IDs (finding 2): id="redtext" and id="whitetext" were reused up to 9 times per page as if they were classes - invalid HTML that breaks anything referencing those IDs. Converted both to classes everywhere (site-wide, including a batch of unquoted id=whitetext attributes an initial grep had missed) and updated the matching CSS selectors. Removed the now-redundant #whitetext rule since an identical .whitetext class already existed.

Contrast failures (finding 3): .footertext p (rgba white at 45% opacity on the navy background) computed to ~4.26:1, under the 4.5:1 AA minimum for normal text. .resume-subheading (50% opacity) computed to ~4.93:1, passing AA only barely. Both bumped to 60% opacity (~6.5:1), a value already used elsewhere on the site.

Skip-to-content link (finding 4): added a link as the first focusable element on every page, visually hidden until it receives keyboard focus, jumping to a new id="main-content" + tabindex="-1" on each page's <main>. Verified it's invisible by default, appears on focus, and correctly moves both scroll position and keyboard focus when activated.