### PR TITLE
Fix mobile flex-basis bug in case-row layout

### DIFF
--- a/new_custom.css
+++ b/new_custom.css
@@ -283,6 +283,12 @@ h3.case-subheading {
 		flex-direction: column;
 		gap: 0.25rem;
 	}
+	.case-row .case-label {
+		flex-basis: auto;
+	}
+	.case-row .case-label:empty {
+		display: none;
+	}
 }
 .case-meta {
 	display: grid;


### PR DESCRIPTION
.case-label's flex: 0 0 8rem sets width in row mode, but once .case-row switches to flex-direction: column on mobile, that same flex-basis controls height instead - leaving an empty 8rem-tall gap wherever a section reused the label column for alignment without repeating the heading text. Reset flex-basis to auto (and collapse now-empty label divs) inside the mobile breakpoint.