### PR TITLE
Hide Projects section, remove About photo/illustration

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,8 @@
 	<div class="row mx-4">
 		<div class="col-12 vspace6em"></div>
 	</div>
+	<!--projects section - hidden-->
+	<div style="display: none !important;">
 	<!--design heading-->
 	<div class="row mx-4" id="work">
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
@@ -260,6 +262,7 @@
 	<div class="row mx-4">
 		<div class="col-12 vspace2em"></div>
 	</div>
+	</div>
 	<!--experience-->
 	<div class="row mx-4" id="experience">
 		<div class="text-col" data-aos="fade-up" data-aos-once="true">
@@ -287,16 +290,6 @@
 					<span class="role whitetext">Northwestern University &mdash; B.S. in Communication Studies, Design, and Marketing</span>
 					<span class="exp-dates">2021</span>
 				</div>
-			</div>
-		</div>
-		<div class="col-12 vspace6em"></div>
-	</div>
-	<!--photo-->
-	<div class="row mx-4">
-		<div class="col-12 text-center">
-			<div class="about-photo-wrap" data-aos="fade-up" data-aos-once="true">
-				<img class="rounded-lg about-photo illustration" src="Images/About/About_illustration_no_text.png" alt="Illustrated portrait of Emma Healy.">
-				<img class="rounded-lg about-photo photo" src="Images/About/About_photo.jpg" alt="Photo of Emma Healy, taken on a disposable camera, in the Amer Palace in Jaipur, Rajasthan, India.">
 			</div>
 		</div>
 		<div class="col-12 vspace6em"></div>


### PR DESCRIPTION
Wrap the entire Projects section (heading, confidentiality disclaimer, category filter bar, and all project cards) in display:none, matching the existing pattern used for individual hidden project cards - content stays in the markup, just not rendered, so it's easy to bring back later.

Remove the About section's illustration/photo hover component entirely (not hidden - deleted, per request).