### PR TITLE
Hide Projects nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 	  </button>
 	  <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
 		<ul class="navbar-nav">
-	  <li class="nav-item">
+	  <li class="nav-item" style="display: none !important;">
 		  <a class="nav-link px-3" href="#work">Projects</a>
 	  </li>
 		  <li class="nav-item">


### PR DESCRIPTION
The Projects section itself is already hidden, so the "Projects" jump link had nowhere useful to go. Hide it too, matching the same display:none convention used for the section.